### PR TITLE
set "seconds" as base time unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.2.0. (2023-06-06)
 
 * Set the base time unit to "seconds", which is required for compatability with the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887) 
+* Support thread name for logging 
 
 ## Version 1.1.0. (2023-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.0. (2023-06-06)
+
+* Set the base time unit to "seconds", which is required for compatability with the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887) 
+
 ## Version 1.1.0. (2023-06-02)
 
 * Add support for log4j

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.2.0. (2023-06-06)
 
-* Set the base time unit to "seconds", which is required for compatability with the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887) 
+* Set the base time unit to "seconds" - which ensures future compatibility with upcoming versions of the Grafana Agent 
 * Support thread name for logging 
 
 ## Version 1.1.0. (2023-06-02)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ you will get the following log output:
 (The `otel.exporter.otlp.headers` field is abbreviated for security reasons.)
 
 If you still don't see your logs, traces and metrics in Grafana, even though the configuration looks good, 
-you can turn on [debug loggong](#grafanaotlpdebuglogging) to what data the application is emitting.
+you can turn on [debug logging](#grafanaotlpdebuglogging) to what data the application is emitting.
 
 ## Properties
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ spring:
 
 ### OpenTelemetry Collector
 
-The configuration in the application is identical to the Grafana agent. 
+The configuration in the application is identical to the Grafana Agent. 
 Whenever this documentation refers to "Grafana Agent", the OpenTelemetry Collector configuration is meant as well.
 
 If you the OpenTelemetry Collector, you can also use the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887), which relies on the prometheus naming conventions (e.g. `_seconds` in the metric names).
@@ -126,7 +126,7 @@ If you the OpenTelemetry Collector, you can also use the recommended [Spring Boo
 - [How to configure the Grafana Agent](https://grafana.com/docs/opentelemetry/instrumentation/grafana-agent/)
 - [Reference](#properties) of all configuration properties
 
-If you have a changed the configuration of the grafana agent,
+If you have a changed the configuration of the Grafana Agent,
 you can specify the endpoint and protocol.
 This example uses the default values - it is equivalent to the example above:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ spring:
 ```
 
 - [How to configure the Grafana Agent](https://grafana.com/docs/opentelemetry/instrumentation/grafana-agent/)
-- [Reference](#properties) of all configuration properties
+- Refer to the [Properties section](#properties) for details about configuration properties
 
 If you have a changed the configuration of the Grafana Agent,
 you can specify the endpoint and protocol.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To register a logback appender, create a new logback-spring.xml (or logback.xml)
     </encoder>
   </appender>
   <appender name="OpenTelemetry"
-            class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+            class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"
+            captureExperimentalAttributes="true">
   </appender>
 
   <root level="INFO">
@@ -71,7 +72,7 @@ To register a log4j2 appender, create a new log4j2.xml file under your projectâ€
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
-    <OpenTelemetry name="OpenTelemetryAppender"/>
+    <OpenTelemetry name="OpenTelemetryAppender" captureExperimentalAttributes="true"/>
   </Appenders>
   <Loggers>
     <Root level="info">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 The grafana-opentelemetry-starter makes it easy to use Metrics, Traces, and Logs with OpenTelemetry
-in Grafana Cloud or with Grafana Agent (for Grafana Cloud or Grafana OSS stack).
+in Grafana Cloud, using the Grafana Agent or OpenTelemetry Collector (for Grafana Cloud or Grafana OSS stack).
 
 # Compatibility
 
@@ -16,7 +16,7 @@ in Grafana Cloud or with Grafana Agent (for Grafana Cloud or Grafana OSS stack).
 Add the following dependency to your `build.gradle`
 
 ```groovy
-implementation 'com.grafana:grafana-opentelemetry-starter:1.1.0'
+implementation 'com.grafana:grafana-opentelemetry-starter:1.2.0'
 ```
 
 ... or `pom.xml`
@@ -25,7 +25,7 @@ implementation 'com.grafana:grafana-opentelemetry-starter:1.1.0'
 <dependency>
     <groupId>com.grafana</groupId>
     <artifactId>grafana-opentelemetry-starter</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 
@@ -84,7 +84,7 @@ To register a log4j2 appender, create a new log4j2.xml file under your projectâ€
 
 ## Configuration
 
-Finally, configure your application.yaml or application.properties either for Grafana Cloud or Grafana Agent.
+Finally, configure your application.yaml or application.properties either for Grafana Cloud, Grafana Agent or OpenTelemetry Collector.
 
 ### Grafana Cloud
 
@@ -115,6 +115,14 @@ spring:
     name: demo-app
 ```
 
+### OpenTelemetry Collector
+
+The configuration in the application is identical to the Grafana agent. 
+Whenever this documentation refers to "Grafana Agent", the OpenTelemetry Collector configuration is meant as well.
+
+If you the OpenTelemetry Collector, you can also use the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887), which relies on the prometheus naming conventions (e.g. `_seconds` in the metric names).
+
+- [How to configure the OpenTelemtry Collector](https://grafana.com/docs/opentelemetry/collector/send-otlp-to-grafana-cloud-databases/)
 - [How to configure the Grafana Agent](https://grafana.com/docs/opentelemetry/instrumentation/grafana-agent/)
 - [Reference](#properties) of all configuration properties
 
@@ -138,7 +146,7 @@ grafana:
 - All configuration properties are described in the [reference](#properties).
 - The `grafana.otlp.cloud` and `grafana.otlp.onprem` properties are mutually exclusive.
 - As usual in Spring Boot, you can use environment variables to supply some of the properties, which is especially
-  useful for secrets, e.g. `GRAFANA_OTLP_CLOUD_API_KEY` instead of `grafana.otlp.cloud.grafana.otlp.cloud.apiKey`.
+  useful for secrets, e.g. `GRAFANA_OTLP_CLOUD_API_KEY` instead of `grafana.otlp.cloud.apiKey`.
 - In addition, you can use all system properties or environment variables from the
   [SDK auto-configuration](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure) -
   which will take precedence.
@@ -151,7 +159,7 @@ For example, if you set the `spring.application.name` in `application.yaml`,
 you will get the following log output:
 
 ```
-11:53:07.724 [main] INFO  c.g.o.OpenTelemetryConfig - using config properties: {otel.exporter.otlp.grafana.otlp.onprem.endpoint=https://otlp-gateway-prod-eu-west-0.grafana.net/otlp, otel.logs.exporter=otlp, otel.traces.exporter=otlp, otel.exporter.otlp.headers=Authorization=Basic NTUz..., otel.exporter.otlp.grafana.otlp.onprem.protocol=http/protobuf, otel.resource.attributes=service.name=demo-app, otel.metrics.exporter=otlp}
+11:53:07.724 [main] INFO  c.g.o.OpenTelemetryConfig - using config properties: {otel.exporter.otlp.endpoint=https://otlp-gateway-prod-eu-west-0.grafana.net/otlp, otel.logs.exporter=otlp, otel.traces.exporter=otlp, otel.exporter.otlp.headers=Authorization=Basic NTUz..., otel.exporter.otlp.protocol=http/protobuf, otel.resource.attributes=service.name=demo-app, otel.metrics.exporter=otlp}
 ```
 
 (The `otel.exporter.otlp.headers` field is abbreviated for security reasons.)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 The grafana-opentelemetry-starter makes it easy to use Metrics, Traces, and Logs with OpenTelemetry
-in Grafana Cloud, using the Grafana Agent or OpenTelemetry Collector (for Grafana Cloud or Grafana OSS stack).
+in Grafana Cloud or with Grafana Agent (for Grafana Cloud or Grafana OSS stack).
 
 # Compatibility
 
@@ -85,7 +85,7 @@ To register a log4j2 appender, create a new log4j2.xml file under your projectâ€
 
 ## Configuration
 
-Finally, configure your application.yaml or application.properties either for Grafana Cloud, Grafana Agent or OpenTelemetry Collector.
+Finally, configure your application.yaml or application.properties either for Grafana Cloud or Grafana Agent.
 
 ### Grafana Cloud
 
@@ -116,14 +116,6 @@ spring:
     name: demo-app
 ```
 
-### OpenTelemetry Collector
-
-The configuration in the application is identical to the Grafana Agent. 
-Whenever this documentation refers to "Grafana Agent", the OpenTelemetry Collector configuration is meant as well.
-
-If you the OpenTelemetry Collector, you can also use the recommended [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887), which relies on the prometheus naming conventions (e.g. `_seconds` in the metric names).
-
-- [How to configure the OpenTelemtry Collector](https://grafana.com/docs/opentelemetry/collector/send-otlp-to-grafana-cloud-databases/)
 - [How to configure the Grafana Agent](https://grafana.com/docs/opentelemetry/instrumentation/grafana-agent/)
 - [Reference](#properties) of all configuration properties
 
@@ -141,6 +133,10 @@ grafana:
       endpoint: http://localhost:4317
       protocol: grpc
 ```
+
+## Grafana Dashboard
+
+Once you've started your application, you can use this [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887)
 
 # Reference
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-grafanaOtelStarterVersion=1.1.0
+grafanaOtelStarterVersion=1.2.0

--- a/src/main/java/com/grafana/opentelemetry/OpenTelemetryConfig.java
+++ b/src/main/java/com/grafana/opentelemetry/OpenTelemetryConfig.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -36,7 +37,10 @@ public class OpenTelemetryConfig {
 
     @Bean
     public MeterRegistry openTelemetryMeterRegistry(OpenTelemetry openTelemetry, Clock clock) {
-        return OpenTelemetryMeterRegistry.builder(openTelemetry).setClock(clock).build();
+        return OpenTelemetryMeterRegistry.builder(openTelemetry)
+                .setClock(clock)
+                .setBaseTimeUnit(TimeUnit.SECONDS)
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
set "seconds" as base time unit, as required by prometheus naming conventions

Needed for https://github.com/grafana/app-o11y/issues/59