### PR TITLE
use records to make parameterized tests easier to understand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Overview
+## Overview
 
 The grafana-opentelemetry-starter makes it easy to use Metrics, Traces, and Logs with OpenTelemetry
 in Grafana Cloud or the Grafana OSS stack.
 
-# Compatibility
+## Compatibility
 
 | Spring Boot Version | Java Version | Recommended Setup                                                                        |
 |---------------------|--------------|------------------------------------------------------------------------------------------|
@@ -14,7 +14,7 @@ in Grafana Cloud or the Grafana OSS stack.
 Logging is supported with Logback and Log4j2 
 (a separate appender is added automatically, leaving your console or file appenders untouched).
 
-# Getting Started
+## Getting Started
 
 Add the following dependency to your `build.gradle`
 
@@ -32,11 +32,11 @@ implementation 'com.grafana:grafana-opentelemetry-starter:1.3.1'
 </dependency>
 ```
 
-## Configuration
+### Configuration
 
 Finally, configure your application.yaml (or application.properties) either for Grafana Cloud OTLP Gateway or Grafana Agent.
 
-### Grafana Cloud OTLP Gateway
+#### Grafana Cloud OTLP Gateway
 
 > ⚠️ Please use the Grafana Agent configuration for production use cases.
 
@@ -66,7 +66,7 @@ grafana:
       apiKey: <Grafana API key>
 ```
 
-### Grafana Agent
+#### Grafana Agent
 
 The Grafana Agent is a single binary that can be deployed as a sidecar or daemonset in Kubernetes, or as a service 
 in your network. It provides an endpoint where the application can send its telemetry data to.
@@ -97,13 +97,18 @@ grafana:
       protocol: grpc
 ```
 
-## Grafana Dashboard
+### Grafana Dashboard
 
 Once you've started your application, you can use this [Spring Boot Dashboard](https://grafana.com/grafana/dashboards/18887)
 
 ![](docs/dashboard.png)
 
-# Reference
+### Getting Help 
+
+If anything is not working, or you have questions about the starter, we’re glad to help you on our 
+[community chat](https://slack.grafana.com/) (#opentelemetry).
+
+## Reference
 
 - All configuration properties are described in the [reference](#properties).
 - The `grafana.otlp.cloud` and `grafana.otlp.onprem` properties are mutually exclusive.
@@ -113,7 +118,7 @@ Once you've started your application, you can use this [Spring Boot Dashboard](h
   [SDK auto-configuration](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure) -
   which will take precedence.
 
-## Troubleshooting
+### Troubleshooting
 
 When you start the application, you will also get a log output of the configuration properties as they are translated into SDK properties.
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ you will get the following log output:
 If you still don't see your logs, traces and metrics in Grafana, even though the configuration looks good, 
 you can turn on [debug logging](#grafanaotlpdebuglogging) to what data the application is emitting.
 
-## Properties
+### Properties
 
-### grafana.otlp.globalAttributes
+#### grafana.otlp.globalAttributes
 
 Adds global (resource) attributes to metrics, traces and logs.
 
@@ -152,31 +152,31 @@ For `service.name` the order of precedence is: <ol> <li>environment variable OTE
 
 The following block can be added to build.gradle to set the application name and version in the jar's MANIFEST.MF: <pre> bootJar { manifest { attributes('Implementation-Title': 'Demo Application', 'Implementation-Version': version) } } </pre> The `service.instance.id` attribute will be set if any of the following return a value. The list is in order of precedence. <ol> <li>InetAddress.getLocalHost().getHostName()</li> <li>environment variable HOSTNAME</li> <li>environment variable HOST</li> </ol>
 
-### grafana.otlp.debugLogging
+#### grafana.otlp.debugLogging
 
 Log all metrics, traces, and logs that are created for debugging purposes (in addition to sending them to the backend via OTLP).
 
 This will also send metrics and traces to Loki as an unintended side effect.
 
-### grafana.otlp.cloud.zone
+#### grafana.otlp.cloud.zone
 
 The Zone can be found when you click on "Details" in the "Grafana" section on grafana.com.
 
 Use `onprem.grafana.otlp.onprem.endpoint` instead of `grafana.otlp.cloud.zone` when using the Grafana Agent.
 
-### grafana.otlp.cloud.instanceId
+#### grafana.otlp.cloud.instanceId
 
 The Instance ID can be found when you click on "Details" in the "Grafana" section on grafana.com.
 
 Leave `grafana.otlp.cloud.instanceId` empty when using the Grafana Agent.
 
-### grafana.otlp.cloud.apiKey
+#### grafana.otlp.cloud.apiKey
 
 Create an API key under "Security" / "API Keys" (left side navigation tree) on grafana.com. The role should be "MetricsPublisher"
 
 Leave `grafana.otlp.cloud.apiKey` empty when using the Grafana Agent.
 
-### grafana.otlp.onprem.endpoint
+#### grafana.otlp.onprem.endpoint
 
 The grafana.otlp.onprem.endpoint of the Grafana Agent.
 
@@ -184,6 +184,6 @@ You do not need to set an `grafana.otlp.onprem.endpoint` value if your Grafana A
 
 Use `cloud.grafana.otlp.cloud.zone` instead of `grafana.otlp.onprem.endpoint` when using the Grafana Cloud.
 
-### grafana.otlp.onprem.protocol
+#### grafana.otlp.onprem.protocol
 
 The grafana.otlp.onprem.protocol used to send OTLP data. Can be either `http/protobuf` or `grpc` (default).

--- a/scripts/update_readme.sh
+++ b/scripts/update_readme.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-sed -i 's/# Documentation/## Properties/g' README.generated
-sed -i --regexp-extended 's/## `(private )?(final )?([^ ]+ )(String> )?([a-zA-Z]+) ?.*`/### \5/g' README.generated
+sed -i 's/# Documentation/### Properties/g' README.generated
+sed -i --regexp-extended 's/## `(private )?(final )?([^ ]+ )(String> )?([a-zA-Z]+) ?.*`/#### \5/g' README.generated
 sed -i 's/endpoint/grafana.otlp.onprem.endpoint/g' README.generated
 sed -i 's/protocol/grafana.otlp.onprem.protocol/g' README.generated
 sed -i 's/zone/grafana.otlp.cloud.zone/g' README.generated

--- a/src/test/java/com/grafana/opentelemetry/OpenTelemetryConfigTest.java
+++ b/src/test/java/com/grafana/opentelemetry/OpenTelemetryConfigTest.java
@@ -1,6 +1,10 @@
 package com.grafana.opentelemetry;
 
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -9,187 +13,188 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
-
 @ExtendWith(OutputCaptureExtension.class)
 class OpenTelemetryConfigTest {
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("overrideCases")
-    void updateResourceAttribute(String name, String expected, String explicit, String[] override) {
-        HashMap<String, String> resourceAttributes = new HashMap<>();
-        if (explicit != null) {
-            resourceAttributes.put(ResourceAttributes.SERVICE_NAME.getKey(), explicit);
-        }
-        OpenTelemetryConfig.updateResourceAttribute(resourceAttributes, ResourceAttributes.SERVICE_NAME,
-                override);
-
-        if (expected == null) {
-            Assertions.assertThat(resourceAttributes).isEmpty();
-        } else {
-            Assertions.assertThat(resourceAttributes)
-                    .containsExactlyEntriesOf(Map.of(ResourceAttributes.SERVICE_NAME.getKey(), expected));
-        }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("overrideCases")
+  void updateResourceAttribute(String name, String expected, String explicit, String[] override) {
+    HashMap<String, String> resourceAttributes = new HashMap<>();
+    if (explicit != null) {
+      resourceAttributes.put(ResourceAttributes.SERVICE_NAME.getKey(), explicit);
     }
+    OpenTelemetryConfig.updateResourceAttribute(
+        resourceAttributes, ResourceAttributes.SERVICE_NAME, override);
 
-    private static Stream<Arguments> overrideCases() {
-        return Stream.of(
-                Arguments.of("explicit name is kept", "explicit", "explicit", new String[]{"ignored"}),
-                Arguments.of("only override is used", "override", null, new String[]{"override"}),
-                Arguments.of("first non-blank override is used", "override", null, new String[]{" ", "override"}),
-                Arguments.of("first non-empty override is used", "override", null, new String[]{"", "override"}),
-                Arguments.of("first non-null override is used", "override", null, new String[]{null, "override"}),
-                Arguments.of("no value found", null, null, new String[]{" ", null})
-        );
+    if (expected == null) {
+      Assertions.assertThat(resourceAttributes).isEmpty();
+    } else {
+      Assertions.assertThat(resourceAttributes)
+          .containsExactlyEntriesOf(Map.of(ResourceAttributes.SERVICE_NAME.getKey(), expected));
     }
+  }
 
-    record BasicAuthTestCase(Optional<String> expected, String expectedOutput,
-                             String apiKey, int instanceId) {
-    }
+  private static Stream<Arguments> overrideCases() {
+    return Stream.of(
+        Arguments.of("explicit name is kept", "explicit", "explicit", new String[] {"ignored"}),
+        Arguments.of("only override is used", "override", null, new String[] {"override"}),
+        Arguments.of(
+            "first non-blank override is used", "override", null, new String[] {" ", "override"}),
+        Arguments.of(
+            "first non-empty override is used", "override", null, new String[] {"", "override"}),
+        Arguments.of(
+            "first non-null override is used", "override", null, new String[] {null, "override"}),
+        Arguments.of("no value found", null, null, new String[] {" ", null}));
+  }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("basicAuthCases")
-    void getBasicAuthHeader(String name, BasicAuthTestCase testCase, CapturedOutput output) {
-        Optional<String> basicAuthHeader = OpenTelemetryConfig.getBasicAuthHeader(testCase.instanceId, testCase.apiKey);
-        Assertions.assertThat(basicAuthHeader).isEqualTo(testCase.expected);
-        Assertions.assertThat(output).contains(testCase.expectedOutput);
-    }
+  record BasicAuthTestCase(
+      Optional<String> expected, String expectedOutput, String apiKey, int instanceId) {}
 
-    private static Stream<Arguments> basicAuthCases() {
-        return Stream.of(
-                Arguments.of("valid basic auth", new BasicAuthTestCase(
-                        Optional.of("Authorization=Basic MTIyMzQ1OmFwaUtleQ=="), "",
-                        "apiKey", 122345
-                )),
-                Arguments.of("API key and instanceId missing", new BasicAuthTestCase(
-                        Optional.empty(), "",
-                        " ", 12345
-                )),
-                Arguments.of("API key blank", new BasicAuthTestCase(
-                        Optional.empty(), "found grafana.otlp.cloud.instanceId but no grafana.otlp.cloud.apiKey",
-                        " ", 12345
-                )),
-                Arguments.of("instanceId 0", new BasicAuthTestCase(
-                        Optional.empty(), "found grafana.otlp.cloud.apiKey but no grafana.otlp.cloud.instanceId",
-                        "apiKey", 0
-                ))
-        );
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("basicAuthCases")
+  void getBasicAuthHeader(String name, BasicAuthTestCase testCase, CapturedOutput output) {
+    Optional<String> basicAuthHeader =
+        OpenTelemetryConfig.getBasicAuthHeader(testCase.instanceId, testCase.apiKey);
+    Assertions.assertThat(basicAuthHeader).isEqualTo(testCase.expected);
+    Assertions.assertThat(output).contains(testCase.expectedOutput);
+  }
 
-    record EndpointTestCase(Optional<String> expected, String expectedOutput,
-                            String zone, String endpoint, Optional<String> authHeader) {
-    }
+  private static Stream<Arguments> basicAuthCases() {
+    return Stream.of(
+        Arguments.of(
+            "valid basic auth",
+            new BasicAuthTestCase(
+                Optional.of("Authorization=Basic MTIyMzQ1OmFwaUtleQ=="), "", "apiKey", 122345)),
+        Arguments.of(
+            "API key and instanceId missing",
+            new BasicAuthTestCase(Optional.empty(), "", " ", 12345)),
+        Arguments.of(
+            "API key blank",
+            new BasicAuthTestCase(
+                Optional.empty(),
+                "found grafana.otlp.cloud.instanceId but no grafana.otlp.cloud.apiKey",
+                " ",
+                12345)),
+        Arguments.of(
+            "instanceId 0",
+            new BasicAuthTestCase(
+                Optional.empty(),
+                "found grafana.otlp.cloud.apiKey but no grafana.otlp.cloud.instanceId",
+                "apiKey",
+                0)));
+  }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("endpointCases")
-    void getEndpoint(String name,
-                     EndpointTestCase testCase,
-                     CapturedOutput output) {
-        Assertions.assertThat(OpenTelemetryConfig.getEndpoint(testCase.endpoint, testCase.zone, testCase.authHeader)).isEqualTo(testCase.expected);
-        Assertions.assertThat(output).contains(testCase.expectedOutput);
-    }
+  record EndpointTestCase(
+      Optional<String> expected,
+      String expectedOutput,
+      String zone,
+      String endpoint,
+      Optional<String> authHeader) {}
 
-    private static Stream<Arguments> endpointCases() {
-        return Stream.of(
-                Arguments.of("only zone", new EndpointTestCase(
-                        Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
-                        "",
-                        "zone",
-                        "",
-                        Optional.of("apiKey")
-                )),
-                Arguments.of("only onprem endpoint", new EndpointTestCase(
-                        Optional.of("endpoint"), "",
-                        "", "endpoint", Optional.empty()
-                )),
-                Arguments.of("both with cloud", new EndpointTestCase(
-                        Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
-                        "ignoring grafana.otlp.onprem.endpoint, because grafana.otlp.cloud.instanceId was found",
-                        "zone", "endpoint", Optional.of("key")
-                )),
-                Arguments.of("zone without instanceId", new EndpointTestCase(
-                        Optional.of("endpoint"),
-                        "ignoring grafana.otlp.cloud.zone, because grafana.otlp.cloud.instanceId was not found",
-                        "zone", "endpoint", Optional.empty()
-                )),
-                Arguments.of("missing zone", new EndpointTestCase(
-                        Optional.empty(),
-                        "please specify grafana.otlp.cloud.zone",
-                        " ", " ", Optional.of("key")
-                )),
-                Arguments.of("onprem endpoint not set", new EndpointTestCase(
-                        Optional.empty(),
-                        "grafana.otlp.onprem.endpoint not found, using default endpoint for otel.exporter.otlp.protocol",
-                        " ", " ", Optional.empty()
-                ))
-        );
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("endpointCases")
+  void getEndpoint(String name, EndpointTestCase testCase, CapturedOutput output) {
+    Assertions.assertThat(
+            OpenTelemetryConfig.getEndpoint(testCase.endpoint, testCase.zone, testCase.authHeader))
+        .isEqualTo(testCase.expected);
+    Assertions.assertThat(output).contains(testCase.expectedOutput);
+  }
 
-    record ProtocolTestCase(String expected, String expectedOutput,
-                            String protocol, Optional<String> authHeader) {
-    }
+  private static Stream<Arguments> endpointCases() {
+    return Stream.of(
+        Arguments.of(
+            "only zone",
+            new EndpointTestCase(
+                Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
+                "",
+                "zone",
+                "",
+                Optional.of("apiKey"))),
+        Arguments.of(
+            "only onprem endpoint",
+            new EndpointTestCase(Optional.of("endpoint"), "", "", "endpoint", Optional.empty())),
+        Arguments.of(
+            "both with cloud",
+            new EndpointTestCase(
+                Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
+                "ignoring grafana.otlp.onprem.endpoint, because grafana.otlp.cloud.instanceId was found",
+                "zone",
+                "endpoint",
+                Optional.of("key"))),
+        Arguments.of(
+            "zone without instanceId",
+            new EndpointTestCase(
+                Optional.of("endpoint"),
+                "ignoring grafana.otlp.cloud.zone, because grafana.otlp.cloud.instanceId was not found",
+                "zone",
+                "endpoint",
+                Optional.empty())),
+        Arguments.of(
+            "missing zone",
+            new EndpointTestCase(
+                Optional.empty(),
+                "please specify grafana.otlp.cloud.zone",
+                " ",
+                " ",
+                Optional.of("key"))),
+        Arguments.of(
+            "onprem endpoint not set",
+            new EndpointTestCase(
+                Optional.empty(),
+                "grafana.otlp.onprem.endpoint not found, using default endpoint for otel.exporter.otlp.protocol",
+                " ",
+                " ",
+                Optional.empty())));
+  }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("protocolCases")
-    void getProtocol(String name, ProtocolTestCase testCase, CapturedOutput output) {
-        Assertions.assertThat(OpenTelemetryConfig.getProtocol(testCase.protocol, testCase.authHeader)).isEqualTo(testCase.expected);
-        Assertions.assertThat(output).contains(testCase.expectedOutput);
-    }
+  record ProtocolTestCase(
+      String expected, String expectedOutput, String protocol, Optional<String> authHeader) {}
 
-    private static Stream<Arguments> protocolCases() {
-        return Stream.of(
-                Arguments.of("cloud", new ProtocolTestCase(
-                        "http/protobuf", "",
-                        "", Optional.of("apiKey")
-                )),
-                Arguments.of("cloud and proto", new ProtocolTestCase(
-                        "http/protobuf",
-                        "ignoring grafana.otlp.onprem.protocol, because grafana.otlp.cloud.instanceId was found",
-                        "grpc", Optional.of("apiKey")
-                )),
-                Arguments.of("onprem", new ProtocolTestCase(
-                        "grpc", "",
-                        "", Optional.empty()
-                )),
-                Arguments.of("onprem and proto", new ProtocolTestCase(
-                        "http/protobuf", "",
-                        "http/protobuf", Optional.empty()
-                ))
-        );
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("protocolCases")
+  void getProtocol(String name, ProtocolTestCase testCase, CapturedOutput output) {
+    Assertions.assertThat(OpenTelemetryConfig.getProtocol(testCase.protocol, testCase.authHeader))
+        .isEqualTo(testCase.expected);
+    Assertions.assertThat(output).contains(testCase.expectedOutput);
+  }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("maskCases")
-    void maskAuthHeader(String name, Map<String, String> expected, Map<String, String> given) {
-        Map<String, String> map = OpenTelemetryConfig.maskAuthHeader(given);
-        Assertions.assertThat(map).containsExactlyInAnyOrderEntriesOf(expected);
-    }
+  private static Stream<Arguments> protocolCases() {
+    return Stream.of(
+        Arguments.of("cloud", new ProtocolTestCase("http/protobuf", "", "", Optional.of("apiKey"))),
+        Arguments.of(
+            "cloud and proto",
+            new ProtocolTestCase(
+                "http/protobuf",
+                "ignoring grafana.otlp.onprem.protocol, because grafana.otlp.cloud.instanceId was found",
+                "grpc",
+                Optional.of("apiKey"))),
+        Arguments.of("onprem", new ProtocolTestCase("grpc", "", "", Optional.empty())),
+        Arguments.of(
+            "onprem and proto",
+            new ProtocolTestCase("http/protobuf", "", "http/protobuf", Optional.empty())));
+  }
 
-    private static Stream<Arguments> maskCases() {
-        return Stream.of(
-                Arguments.of("masked",
-                        Map.of(
-                                "foo", "bar",
-                                OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUz..."),
-                        Map.of(
-                                "foo", "bar",
-                                OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUzMzg2OmV5SnJJam9pW")),
-                Arguments.of("short auth header",
-                        Map.of(
-                                "foo", "bar",
-                                OpenTelemetryConfig.OTLP_HEADERS, ""),
-                        Map.of(
-                                "foo", "bar",
-                                OpenTelemetryConfig.OTLP_HEADERS, "")),
-                Arguments.of("no auth header",
-                        Map.of(
-                                "foo", "bar"),
-                        Map.of(
-                                "foo", "bar"))
-        );
-    }
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("maskCases")
+  void maskAuthHeader(String name, Map<String, String> expected, Map<String, String> given) {
+    Map<String, String> map = OpenTelemetryConfig.maskAuthHeader(given);
+    Assertions.assertThat(map).containsExactlyInAnyOrderEntriesOf(expected);
+  }
 
+  private static Stream<Arguments> maskCases() {
+    return Stream.of(
+        Arguments.of(
+            "masked",
+            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUz..."),
+            Map.of(
+                "foo",
+                "bar",
+                OpenTelemetryConfig.OTLP_HEADERS,
+                "Authorization=Basic NTUzMzg2OmV5SnJJam9pW")),
+        Arguments.of(
+            "short auth header",
+            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, ""),
+            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, "")),
+        Arguments.of("no auth header", Map.of("foo", "bar"), Map.of("foo", "bar")));
+  }
 }

--- a/src/test/java/com/grafana/opentelemetry/OpenTelemetryConfigTest.java
+++ b/src/test/java/com/grafana/opentelemetry/OpenTelemetryConfigTest.java
@@ -1,10 +1,6 @@
 package com.grafana.opentelemetry;
 
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,181 +9,187 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 @ExtendWith(OutputCaptureExtension.class)
 class OpenTelemetryConfigTest {
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("overrideCases")
-  void updateResourceAttribute(String name, String expected, String explicit, String[] override) {
-    HashMap<String, String> resourceAttributes = new HashMap<>();
-    if (explicit != null) {
-      resourceAttributes.put(ResourceAttributes.SERVICE_NAME.getKey(), explicit);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("overrideCases")
+    void updateResourceAttribute(String name, String expected, String explicit, String[] override) {
+        HashMap<String, String> resourceAttributes = new HashMap<>();
+        if (explicit != null) {
+            resourceAttributes.put(ResourceAttributes.SERVICE_NAME.getKey(), explicit);
+        }
+        OpenTelemetryConfig.updateResourceAttribute(resourceAttributes, ResourceAttributes.SERVICE_NAME,
+                override);
+
+        if (expected == null) {
+            Assertions.assertThat(resourceAttributes).isEmpty();
+        } else {
+            Assertions.assertThat(resourceAttributes)
+                    .containsExactlyEntriesOf(Map.of(ResourceAttributes.SERVICE_NAME.getKey(), expected));
+        }
     }
-    OpenTelemetryConfig.updateResourceAttribute(
-        resourceAttributes, ResourceAttributes.SERVICE_NAME, override);
 
-    if (expected == null) {
-      Assertions.assertThat(resourceAttributes).isEmpty();
-    } else {
-      Assertions.assertThat(resourceAttributes)
-          .containsExactlyEntriesOf(Map.of(ResourceAttributes.SERVICE_NAME.getKey(), expected));
+    private static Stream<Arguments> overrideCases() {
+        return Stream.of(
+                Arguments.of("explicit name is kept", "explicit", "explicit", new String[]{"ignored"}),
+                Arguments.of("only override is used", "override", null, new String[]{"override"}),
+                Arguments.of("first non-blank override is used", "override", null, new String[]{" ", "override"}),
+                Arguments.of("first non-empty override is used", "override", null, new String[]{"", "override"}),
+                Arguments.of("first non-null override is used", "override", null, new String[]{null, "override"}),
+                Arguments.of("no value found", null, null, new String[]{" ", null})
+        );
     }
-  }
 
-  private static Stream<Arguments> overrideCases() {
-    return Stream.of(
-        Arguments.of("explicit name is kept", "explicit", "explicit", new String[] {"ignored"}),
-        Arguments.of("only override is used", "override", null, new String[] {"override"}),
-        Arguments.of(
-            "first non-blank override is used", "override", null, new String[] {" ", "override"}),
-        Arguments.of(
-            "first non-empty override is used", "override", null, new String[] {"", "override"}),
-        Arguments.of(
-            "first non-null override is used", "override", null, new String[] {null, "override"}),
-        Arguments.of("no value found", null, null, new String[] {" ", null}));
-  }
+    record BasicAuthTestCase(Optional<String> expected, String expectedOutput,
+                             String apiKey, int instanceId) {
+    }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("basicAuthCases")
-  void getBasicAuthHeader(
-      String name,
-      Optional<String> expected,
-      String expectedOutput,
-      String apiKey,
-      int instanceId,
-      CapturedOutput output) {
-    Optional<String> basicAuthHeader = OpenTelemetryConfig.getBasicAuthHeader(instanceId, apiKey);
-    Assertions.assertThat(basicAuthHeader).isEqualTo(expected);
-    Assertions.assertThat(output).contains(expectedOutput);
-  }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("basicAuthCases")
+    void getBasicAuthHeader(String name, BasicAuthTestCase testCase, CapturedOutput output) {
+        Optional<String> basicAuthHeader = OpenTelemetryConfig.getBasicAuthHeader(testCase.instanceId, testCase.apiKey);
+        Assertions.assertThat(basicAuthHeader).isEqualTo(testCase.expected);
+        Assertions.assertThat(output).contains(testCase.expectedOutput);
+    }
 
-  private static Stream<Arguments> basicAuthCases() {
-    return Stream.of(
-        Arguments.of(
-            "valid basic auth",
-            Optional.of("Authorization=Basic MTIyMzQ1OmFwaUtleQ=="),
-            "",
-            "apiKey",
-            122345),
-        Arguments.of("API key and instanceId missing", Optional.empty(), "", " ", 12345),
-        Arguments.of(
-            "API key blank",
-            Optional.empty(),
-            "found grafana.otlp.cloud.instanceId but no grafana.otlp.cloud.apiKey",
-            " ",
-            12345),
-        Arguments.of(
-            "instanceId 0",
-            Optional.empty(),
-            "found grafana.otlp.cloud.apiKey but no grafana.otlp.cloud.instanceId",
-            "apiKey",
-            0));
-  }
+    private static Stream<Arguments> basicAuthCases() {
+        return Stream.of(
+                Arguments.of("valid basic auth", new BasicAuthTestCase(
+                        Optional.of("Authorization=Basic MTIyMzQ1OmFwaUtleQ=="), "",
+                        "apiKey", 122345
+                )),
+                Arguments.of("API key and instanceId missing", new BasicAuthTestCase(
+                        Optional.empty(), "",
+                        " ", 12345
+                )),
+                Arguments.of("API key blank", new BasicAuthTestCase(
+                        Optional.empty(), "found grafana.otlp.cloud.instanceId but no grafana.otlp.cloud.apiKey",
+                        " ", 12345
+                )),
+                Arguments.of("instanceId 0", new BasicAuthTestCase(
+                        Optional.empty(), "found grafana.otlp.cloud.apiKey but no grafana.otlp.cloud.instanceId",
+                        "apiKey", 0
+                ))
+        );
+    }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("endpointCases")
-  void getEndpoint(
-      String name,
-      Optional<String> expected,
-      String expectedOutput,
-      String zone,
-      String endpoint,
-      Optional<String> authHeader,
-      CapturedOutput output) {
-    Assertions.assertThat(OpenTelemetryConfig.getEndpoint(endpoint, zone, authHeader))
-        .isEqualTo(expected);
-    Assertions.assertThat(output).contains(expectedOutput);
-  }
+    record EndpointTestCase(Optional<String> expected, String expectedOutput,
+                            String zone, String endpoint, Optional<String> authHeader) {
+    }
 
-  private static Stream<Arguments> endpointCases() {
-    return Stream.of(
-        Arguments.of(
-            "only zone",
-            Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
-            "",
-            "zone",
-            "",
-            Optional.of("apiKey")),
-        Arguments.of(
-            "only onprem endpoint", Optional.of("endpoint"), "", "", "endpoint", Optional.empty()),
-        Arguments.of(
-            "both with cloud",
-            Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
-            "ignoring grafana.otlp.onprem.endpoint, because grafana.otlp.cloud.instanceId was found",
-            "zone",
-            "endpoint",
-            Optional.of("key")),
-        Arguments.of(
-            "zone without instanceId",
-            Optional.of("endpoint"),
-            "ignoring grafana.otlp.cloud.zone, because grafana.otlp.cloud.instanceId was not found",
-            "zone",
-            "endpoint",
-            Optional.empty()),
-        Arguments.of(
-            "missing zone",
-            Optional.empty(),
-            "please specify grafana.otlp.cloud.zone",
-            " ",
-            " ",
-            Optional.of("key")),
-        Arguments.of(
-            "onprem endpoint not set",
-            Optional.empty(),
-            "grafana.otlp.onprem.endpoint not found, using default endpoint for otel.exporter.otlp.protocol",
-            " ",
-            " ",
-            Optional.empty()));
-  }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("endpointCases")
+    void getEndpoint(String name,
+                     EndpointTestCase testCase,
+                     CapturedOutput output) {
+        Assertions.assertThat(OpenTelemetryConfig.getEndpoint(testCase.endpoint, testCase.zone, testCase.authHeader)).isEqualTo(testCase.expected);
+        Assertions.assertThat(output).contains(testCase.expectedOutput);
+    }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("protocolCases")
-  void getProtocol(
-      String name,
-      String expected,
-      String expectedOutput,
-      String protocol,
-      Optional<String> authHeader,
-      CapturedOutput output) {
-    Assertions.assertThat(OpenTelemetryConfig.getProtocol(protocol, authHeader))
-        .isEqualTo(expected);
-    Assertions.assertThat(output).contains(expectedOutput);
-  }
+    private static Stream<Arguments> endpointCases() {
+        return Stream.of(
+                Arguments.of("only zone", new EndpointTestCase(
+                        Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
+                        "",
+                        "zone",
+                        "",
+                        Optional.of("apiKey")
+                )),
+                Arguments.of("only onprem endpoint", new EndpointTestCase(
+                        Optional.of("endpoint"), "",
+                        "", "endpoint", Optional.empty()
+                )),
+                Arguments.of("both with cloud", new EndpointTestCase(
+                        Optional.of("https://otlp-gateway-zone.grafana.net/otlp"),
+                        "ignoring grafana.otlp.onprem.endpoint, because grafana.otlp.cloud.instanceId was found",
+                        "zone", "endpoint", Optional.of("key")
+                )),
+                Arguments.of("zone without instanceId", new EndpointTestCase(
+                        Optional.of("endpoint"),
+                        "ignoring grafana.otlp.cloud.zone, because grafana.otlp.cloud.instanceId was not found",
+                        "zone", "endpoint", Optional.empty()
+                )),
+                Arguments.of("missing zone", new EndpointTestCase(
+                        Optional.empty(),
+                        "please specify grafana.otlp.cloud.zone",
+                        " ", " ", Optional.of("key")
+                )),
+                Arguments.of("onprem endpoint not set", new EndpointTestCase(
+                        Optional.empty(),
+                        "grafana.otlp.onprem.endpoint not found, using default endpoint for otel.exporter.otlp.protocol",
+                        " ", " ", Optional.empty()
+                ))
+        );
+    }
 
-  private static Stream<Arguments> protocolCases() {
-    return Stream.of(
-        Arguments.of("cloud", "http/protobuf", "", "", Optional.of("apiKey")),
-        Arguments.of(
-            "cloud and proto",
-            "http/protobuf",
-            "ignoring grafana.otlp.onprem.protocol, because grafana.otlp.cloud.instanceId was found",
-            "grpc",
-            Optional.of("apiKey")),
-        Arguments.of("onprem", "grpc", "", "", Optional.empty()),
-        Arguments.of("onprem and proto", "http/protobuf", "", "http/protobuf", Optional.empty()));
-  }
+    record ProtocolTestCase(String expected, String expectedOutput,
+                            String protocol, Optional<String> authHeader) {
+    }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("maskCases")
-  void maskAuthHeader(String name, Map<String, String> expected, Map<String, String> given) {
-    Map<String, String> map = OpenTelemetryConfig.maskAuthHeader(given);
-    Assertions.assertThat(map).containsExactlyInAnyOrderEntriesOf(expected);
-  }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("protocolCases")
+    void getProtocol(String name, ProtocolTestCase testCase, CapturedOutput output) {
+        Assertions.assertThat(OpenTelemetryConfig.getProtocol(testCase.protocol, testCase.authHeader)).isEqualTo(testCase.expected);
+        Assertions.assertThat(output).contains(testCase.expectedOutput);
+    }
 
-  private static Stream<Arguments> maskCases() {
-    return Stream.of(
-        Arguments.of(
-            "masked",
-            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUz..."),
-            Map.of(
-                "foo",
-                "bar",
-                OpenTelemetryConfig.OTLP_HEADERS,
-                "Authorization=Basic NTUzMzg2OmV5SnJJam9pW")),
-        Arguments.of(
-            "short auth header",
-            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, ""),
-            Map.of("foo", "bar", OpenTelemetryConfig.OTLP_HEADERS, "")),
-        Arguments.of("no auth header", Map.of("foo", "bar"), Map.of("foo", "bar")));
-  }
+    private static Stream<Arguments> protocolCases() {
+        return Stream.of(
+                Arguments.of("cloud", new ProtocolTestCase(
+                        "http/protobuf", "",
+                        "", Optional.of("apiKey")
+                )),
+                Arguments.of("cloud and proto", new ProtocolTestCase(
+                        "http/protobuf",
+                        "ignoring grafana.otlp.onprem.protocol, because grafana.otlp.cloud.instanceId was found",
+                        "grpc", Optional.of("apiKey")
+                )),
+                Arguments.of("onprem", new ProtocolTestCase(
+                        "grpc", "",
+                        "", Optional.empty()
+                )),
+                Arguments.of("onprem and proto", new ProtocolTestCase(
+                        "http/protobuf", "",
+                        "http/protobuf", Optional.empty()
+                ))
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("maskCases")
+    void maskAuthHeader(String name, Map<String, String> expected, Map<String, String> given) {
+        Map<String, String> map = OpenTelemetryConfig.maskAuthHeader(given);
+        Assertions.assertThat(map).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    private static Stream<Arguments> maskCases() {
+        return Stream.of(
+                Arguments.of("masked",
+                        Map.of(
+                                "foo", "bar",
+                                OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUz..."),
+                        Map.of(
+                                "foo", "bar",
+                                OpenTelemetryConfig.OTLP_HEADERS, "Authorization=Basic NTUzMzg2OmV5SnJJam9pW")),
+                Arguments.of("short auth header",
+                        Map.of(
+                                "foo", "bar",
+                                OpenTelemetryConfig.OTLP_HEADERS, ""),
+                        Map.of(
+                                "foo", "bar",
+                                OpenTelemetryConfig.OTLP_HEADERS, "")),
+                Arguments.of("no auth header",
+                        Map.of(
+                                "foo", "bar"),
+                        Map.of(
+                                "foo", "bar"))
+        );
+    }
+
 }


### PR DESCRIPTION
much easier to understand (type hints from IDEA) and easier to get right (because you can't miss a parameter)

![image](https://github.com/grafana/grafana-opentelemetry-starter/assets/2832627/0acbb9dd-9114-4cd0-81b0-c5373fd15f07)
